### PR TITLE
Fix missing_charset warning when setting status

### DIFF
--- a/slack_wlan_status_updater/status_setter.py
+++ b/slack_wlan_status_updater/status_setter.py
@@ -27,7 +27,7 @@ class SlackStatusSetter(StatusSetter):
         }
         url = "https://slack.com/api/users.profile.set"
         headers = {
-            "Content-type": "application/json",
+            "Content-type": "application/json; charset=utf-8",
             "Authorization": f"Bearer {self._token}",
         }
         request = urllib.request.Request(


### PR DESCRIPTION
Thanks for the project, it's working well for me. 🙂 
The Slack server response says `{'ok': True, ..., 'warning': 'missing_charset', 'response_metadata': {'warnings': ['missing_charset']}}`. I specified utf-8 to silence the warning.